### PR TITLE
drop source build of fake_joint_driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - TEST=catkin_lint
 
 before_script:
-  - git clone --depth=1 https://github.com/tork-a/fake_joint && touch fake_joint/fake_joint/CATKIN_IGNORE && touch fake_joint/fake_joint_launch/CATKIN_IGNORE ## not yet available as binary package
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci
 
 script:

--- a/prbt_jog_arm_support/README.md
+++ b/prbt_jog_arm_support/README.md
@@ -12,14 +12,6 @@ This Package contains files to launch the prbt with moveit_jog_arm and tork-a/fa
 
 - Clone this package into the src directory `git clone https://github.com/PilzDE/pilz_teach` 
 
-- Get tork-a/fake_joint for simulation but because of unpackaged dependencies only build fake_joint_driver:
-
-  ```shell script
-  git clone https://github.com/tork-a/fake_joint
-  touch fake_joint/fake_joint/CATKIN_IGNORE
-  touch fake_joint/fake_joint_launch/CATKIN_IGNORE
-  ```
-
 - In `~/catkin_ws` install all the dependencies `rosdep install -y --from-paths src --ignore-src`
 
 - Build the workspace e.g. using `catkin build` and `source devel/setup.bash`


### PR DESCRIPTION
since it is now available as melodic package