### PR TITLE
Feature/teleoperation tests (#34)

### DIFF
--- a/pilz_teleoperation/CMakeLists.txt
+++ b/pilz_teleoperation/CMakeLists.txt
@@ -3,6 +3,7 @@ project(pilz_teleoperation)
 
 find_package(catkin REQUIRED COMPONENTS
   message_generation
+  roslint
   rospy
   std_msgs
 )
@@ -19,4 +20,40 @@ catkin_package(CATKIN_DEPENDS message_runtime)
 catkin_install_python(PROGRAMS 
     scripts/key_teleop.py
     scripts/pilz_teleop_driver.py
-	DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+#############
+## Testing ##
+#############
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  find_package(ros_pytest REQUIRED)
+
+  include_directories(
+    ${catkin_INCLUDE_DIRS}
+  )
+
+  file(GLOB integrationtest_files "test/integrationtests/*.test")
+  foreach(file ${integrationtest_files})
+    if(ENABLE_COVERAGE_TESTING)
+        add_rostest(${file} ARGS coverage:=TRUE)
+    else()
+        add_rostest(${file})
+    endif()
+  endforeach()
+
+  file(GLOB unittest_files "test/unittests/tst_*.py")
+  foreach(file ${unittest_files})
+    if(ENABLE_COVERAGE_TESTING) 
+      add_pytests(${file} ARGS coverage:=TRUE)
+    else()
+      add_pytests(${file})
+    endif()
+  endforeach()
+
+  # check for pep8 compliance and fail test on error(s)
+  roslint_python( )
+  roslint_add_test()
+
+endif()

--- a/pilz_teleoperation/package.xml
+++ b/pilz_teleoperation/package.xml
@@ -15,12 +15,19 @@
   <url type="repository">https://github.com/PilzDE/pilz_teach</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>roslint</build_depend>
+
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>rospy_message_converter</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>control_msgs</exec_depend>
   <exec_depend>rospy</exec_depend>
+
+  <test_depend>python-mock</test_depend>
+  <test_depend>rostest</test_depend>
+  <test_depend>ros_pytest</test_depend>
 </package>

--- a/pilz_teleoperation/scripts/key_teleop.py
+++ b/pilz_teleoperation/scripts/key_teleop.py
@@ -42,4 +42,3 @@ if __name__ == '__main__':
         curses.wrapper(main)
     except rospy.ROSInterruptException:
         pass
-

--- a/pilz_teleoperation/setup.py
+++ b/pilz_teleoperation/setup.py
@@ -1,4 +1,4 @@
-## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+# ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
 from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup

--- a/pilz_teleoperation/test/integrationtests/tst_key_teleop.py
+++ b/pilz_teleoperation/test/integrationtests/tst_key_teleop.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# Copyright (c) 2019 Pilz GmbH & Co. KG
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import rospy
+import unittest
+
+from geometry_msgs.msg import TwistStamped
+from control_msgs.msg import JointJog
+
+
+class TestKeyTeleoperation(unittest.TestCase):
+    """
+    Test that the key_teleoperation file brings up the teleoperation driver and calls its update method
+    """
+    def __init__(self, *args, **kwargs):
+        super(TestKeyTeleoperation, self).__init__(*args, **kwargs)
+        self.twist_published = False
+
+    def setUp(self):
+        rospy.loginfo("SetUp called...")
+
+    def tearDown(self):
+        rospy.loginfo("TearDown called...")
+
+    def callback(self, msg):
+        self.twist_published = True
+
+    def test_startup(self):
+        """ Test if driver gets started """
+        subscriber_twist = rospy.Subscriber('/jog_server/delta_jog_cmds', TwistStamped, self.callback)
+        subscriber_joint = rospy.Subscriber('/jog_server/joint_delta_jog_cmds', JointJog, self.callback)
+
+        timeout = rospy.Time().now() + rospy.Duration(secs=10)
+        while not rospy.is_shutdown() and not self.twist_published:
+            rospy.sleep(0.1)
+            self.assertTrue(rospy.Time().now() < timeout, "driver did not publish")
+        subscriber_twist.unregister()
+        subscriber_joint.unregister()
+
+
+if __name__ == '__main__':
+    import rostest
+
+    rospy.init_node('tst_key_teleoperation')
+    rostest.rosrun('pilz_teleoperation', 'tst_key_teleop', TestKeyTeleoperation)

--- a/pilz_teleoperation/test/integrationtests/tst_key_teleop.test
+++ b/pilz_teleoperation/test/integrationtests/tst_key_teleop.test
@@ -1,0 +1,30 @@
+<!--
+Copyright (c) 2019 Pilz GmbH & Co. KG
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<launch>
+  <arg name="coverage" default="false"/>
+  <arg name="pythontest_launch_prefix" value="$(eval 'python-coverage run -p' if arg('coverage') else '')"/>
+
+  <include file="$(find pilz_teleoperation)/launch/key_teleop.launch">
+  </include>
+
+  <!-- test node -->
+  <test test-name="test_key_teleoperation" pkg="pilz_teleoperation"
+    type="tst_key_teleop.py" time-limit="200"
+    launch-prefix="$(arg pythontest_launch_prefix)"/>
+
+</launch>

--- a/pilz_teleoperation/test/unittests/tst_teleoperation_driver.py
+++ b/pilz_teleoperation/test/unittests/tst_teleoperation_driver.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import mock
+from pilz_teleoperation import TeleoperationDriver
+from pilz_teleoperation.srv import SetTeleopSettingsRequest
+
+import ros_pytest
+
+
+class TestTeleoperationDriver():
+    @mock.patch('rospy.rostime.get_rostime')
+    def test_window_update_after_config_change(self, mocked_rostime):
+        mocked_rostime.return_value = 0
+        win_mock = mock.MagicMock()
+        driver = TeleoperationDriver(window=win_mock)
+        assert win_mock.driver_settings_changed.call_count == 1
+        driver.set_teleop_settings(SetTeleopSettingsRequest(
+            pressed_commands=[SetTeleopSettingsRequest.TOGGLE_JOINT_UP]))
+        assert win_mock.driver_settings_changed.call_count == 2

--- a/prbt_jog_arm_support/package.xml
+++ b/prbt_jog_arm_support/package.xml
@@ -21,6 +21,8 @@
   <exec_depend>prbt_support</exec_depend>
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>prbt_moveit_config</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>prbt_hardware_support</exec_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>pilz_robot_programming</test_depend>

--- a/prbt_jog_arm_support/test/integrationtests/tst_jog_arm_motion.py
+++ b/prbt_jog_arm_support/test/integrationtests/tst_jog_arm_motion.py
@@ -34,13 +34,14 @@ class TestJogArmMotion(unittest.TestCase):
 
     def tearDown(self):
         rospy.loginfo("TearDown called...")
+        self.r.__del__
 
     def test_move(self):
         """ Test,  if the robot moves on sending a twist command message"""
         # Wait until jog-arm-server is ready
         # topic: /jog_server/delta_jog_cmds
         publisher = rospy.Publisher('/jog_server/delta_jog_cmds', TwistStamped)
-        while publisher.get_num_connections() < 1:
+        while (publisher.get_num_connections() < 1) and (not rospy.is_shutdown()):
             rospy.sleep(0.1)
         
         # get current robot position
@@ -55,12 +56,13 @@ class TestJogArmMotion(unittest.TestCase):
               
         # wait until current robot position changes
         timeout = rospy.Time().now() + rospy.Duration(10.)
-        while(start_pose == self.r.get_current_pose()):
+        while (start_pose == self.r.get_current_pose()) and (not rospy.is_shutdown()):
             rospy.sleep(0.1)
             self.assertTrue(rospy.Time().now() < timeout, "robot did not move until timeout")
+        publisher.unregister()
 
 
 if __name__ == '__main__':
     import rostest
     rospy.init_node('tst_jog_arm_motion')
-    rostest.rosrun('pilz_jog_arm_suppport', 'tst_jog_arm_motion', TestJogArmMotion)
+    rostest.rosrun('prbt_jog_arm_support', 'tst_jog_arm_motion', TestJogArmMotion)


### PR DESCRIPTION
added integration and modultest setup and example test

* adapt parameter names to upstream changes (#42)

in moveit_experimental/jog_arm

* added code coverage dependency
* added python-mock dependency
* added coverage arg to rostests
* fixes catkin_lint errors + warnings
* drop coverage for now
* python_lint without arguments checks all *.py files
* rename modul->unittests

Co-authored-by: tobi-v <t_vetter@live.de>
Co-authored-by: jschleicher <j.schleicher@pilz.de>
Co-authored-by: rfeistenauer <45563842+rfeistenauer@users.noreply.github.com>